### PR TITLE
adding network level tests

### DIFF
--- a/tests/config.json
+++ b/tests/config.json
@@ -2,4 +2,6 @@
   "location": "southeastasia",
   "bastionInboundRules": ["443", "135", "4443", "*", "*", "*"],
   "bastionOutboundRules": ["*", "*", "*", "22", "443", "3389"],
+  "jumpboxInboundRules": ["22", "*", "*", "*"],
+  "jumpboxOutboundRules": ["*", "*", "*"],
 }

--- a/tests/config.json
+++ b/tests/config.json
@@ -1,3 +1,5 @@
 {
-  "location": "southeastasia"
+  "location": "southeastasia",
+  "bastionInboundRules": ["443", "135", "4443", "*", "*", "*"],
+  "bastionOutboundRules": ["*", "*", "*", "22", "443", "3389"],
 }

--- a/tests/config.json
+++ b/tests/config.json
@@ -4,4 +4,6 @@
   "bastionOutboundRules": ["*", "*", "*", "22", "443", "3389"],
   "jumpboxInboundRules": ["22", "*", "*", "*"],
   "jumpboxOutboundRules": ["*", "*", "*"],
+  "privateEndpointsInboundRules": ["*", "*", "*"],
+  "privateEndpointsOutboundRules": ["*", "*", "*"]
 }

--- a/tests/level2_test.go
+++ b/tests/level2_test.go
@@ -72,26 +72,3 @@ func TestSharedServicesHasRecoveryServiceVault(t *testing.T) {
 
 	assert.True(t, exist, fmt.Sprintf("Expected Recovery Service Vault does not exists with '%s-rsv-vaultre1' name, under the resource group with 'landingzone=shared_services' tag", test.Prefix))
 }
-
-func TestSharedServicesHasTwoResourceGroupForNetworkingHub(t *testing.T) {
-	t.Parallel()
-
-	test := prepareTestTable()
-
-	client, _ := azure.GetResourceGroupClientE(test.SubscriptionID)
-
-	result, _ := client.List(context.Background(), "tagName eq 'level' and tagValue eq 'level2'", nil)
-
-	rgList := result.Values()
-
-	actual := 0
-	for _, rg := range rgList {
-		if *rg.Tags["landingzone"] == "networking_hub" && *rg.Tags["environment"] == test.Environment {
-			actual++
-		}
-	}
-
-	expected := 2
-
-	assert.Equal(t, expected, actual, fmt.Sprintf("There must be %d resource group with 'landingzone=networking_hub' and 'environment=%s' tags, found %d", expected, test.Environment, actual))
-}

--- a/tests/level3_test.go
+++ b/tests/level3_test.go
@@ -67,3 +67,15 @@ func TestJumpboxSecurityRulesCount(t *testing.T) {
 		assert.Equal(t, 7, len(rules.SummarizedRules), fmt.Sprintf("Jumpbox should have 7 rules, found %d", len(rules.SummarizedRules)))
 	}
 }
+
+func TestPrivateEndpointsSecurityRulesCount(t *testing.T) {
+	t.Parallel()
+
+	test := prepareTestTable()
+
+	for iLoop := 1; iLoop <= 2; iLoop++ {
+		rules := azure.GetAllNSGRules(t, fmt.Sprintf("%s-rg-vnet-hub-re%d", test.Prefix, iLoop), fmt.Sprintf("%s-nsg-private_endpoints", test.Prefix), test.SubscriptionID)
+
+		assert.Equal(t, 6, len(rules.SummarizedRules), fmt.Sprintf("Private Endpoints should have 6 rules, found %d", len(rules.SummarizedRules)))
+	}
+}

--- a/tests/level3_test.go
+++ b/tests/level3_test.go
@@ -8,3 +8,26 @@ import (
 	"github.com/gruntwork-io/terratest/modules/azure"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestThereAreTwoResourceGroupsForNetworkingHub(t *testing.T) {
+	t.Parallel()
+
+	test := prepareTestTable()
+
+	client, _ := azure.GetResourceGroupClientE(test.SubscriptionID)
+
+	result, _ := client.List(context.Background(), "tagName eq 'level' and tagValue eq 'level2'", nil)
+
+	rgList := result.Values()
+
+	actual := 0
+	for _, rg := range rgList {
+		if *rg.Tags["landingzone"] == "networking_hub" && *rg.Tags["environment"] == test.Environment {
+			actual++
+		}
+	}
+
+	expected := 2
+
+	assert.Equal(t, expected, actual, fmt.Sprintf("There must be %d resource group with 'landingzone=networking_hub' and 'environment=%s' tags, found %d", expected, test.Environment, actual))
+}

--- a/tests/level3_test.go
+++ b/tests/level3_test.go
@@ -155,3 +155,22 @@ func TestPrivateEndpointsSecurityRulesCount(t *testing.T) {
 		assert.Equal(t, 6, len(rules.SummarizedRules), fmt.Sprintf("Private Endpoints should have 6 rules, found %d", len(rules.SummarizedRules)))
 	}
 }
+
+func TestPrivateEndpointsInboundSecurityRules(t *testing.T) {
+	t.Parallel()
+
+	test := prepareTestTable()
+
+	for iLoop := 1; iLoop <= 2; iLoop++ {
+		rules := azure.GetAllNSGRules(t, fmt.Sprintf("%s-rg-vnet-hub-re%d", test.Prefix, iLoop), fmt.Sprintf("%s-nsg-private_endpoints", test.Prefix), test.SubscriptionID)
+		actual := make([]string, 0)
+
+		for _, rule := range rules.SummarizedRules {
+			if rule.Direction == "Inbound" {
+				actual = append(actual, rule.DestinationPortRange)
+			}
+		}
+
+		assert.ElementsMatch(t, test.Config.PrivateEndpointsInboundRules, actual, fmt.Sprintf("PrivateEndpoints doesn't have expected destination ports: %+q", test.Config.PrivateEndpointsInboundRules))
+	}
+}

--- a/tests/level3_test.go
+++ b/tests/level3_test.go
@@ -106,6 +106,24 @@ func TestJumpboxSecurityRulesCount(t *testing.T) {
 	}
 }
 
+func TestJumpboxInboundSecurityRules(t *testing.T) {
+	t.Parallel()
+
+	test := prepareTestTable()
+
+	for iLoop := 1; iLoop <= 2; iLoop++ {
+		rules := azure.GetAllNSGRules(t, fmt.Sprintf("%s-rg-vnet-hub-re%d", test.Prefix, iLoop), fmt.Sprintf("%s-nsg-jumpbox", test.Prefix), test.SubscriptionID)
+		actual := make([]string, 0)
+
+		for _, rule := range rules.SummarizedRules {
+			if rule.Direction == "Inbound" {
+				actual = append(actual, rule.DestinationPortRange)
+			}
+		}
+
+		assert.ElementsMatch(t, test.Config.JumpboxInboundRules, actual, fmt.Sprintf("Jumpbox doesn't have expected destination ports: %+q", test.Config.JumpboxInboundRules))
+	}
+}
 func TestPrivateEndpointsSecurityRulesCount(t *testing.T) {
 	t.Parallel()
 

--- a/tests/level3_test.go
+++ b/tests/level3_test.go
@@ -55,3 +55,15 @@ func TestBastionSubNetSecurityRulesCount(t *testing.T) {
 		assert.Equal(t, 12, len(rules.SummarizedRules), fmt.Sprintf("Bastion Subnet should have 12 rules, found %d", len(rules.SummarizedRules)))
 	}
 }
+
+func TestJumpboxSecurityRulesCount(t *testing.T) {
+	t.Parallel()
+
+	test := prepareTestTable()
+
+	for iLoop := 1; iLoop <= 2; iLoop++ {
+		rules := azure.GetAllNSGRules(t, fmt.Sprintf("%s-rg-vnet-hub-re%d", test.Prefix, iLoop), fmt.Sprintf("%s-nsg-jumpbox", test.Prefix), test.SubscriptionID)
+
+		assert.Equal(t, 7, len(rules.SummarizedRules), fmt.Sprintf("Jumpbox should have 7 rules, found %d", len(rules.SummarizedRules)))
+	}
+}

--- a/tests/level3_test.go
+++ b/tests/level3_test.go
@@ -31,3 +31,15 @@ func TestThereAreTwoResourceGroupsForNetworkingHub(t *testing.T) {
 
 	assert.Equal(t, expected, actual, fmt.Sprintf("There must be %d resource group with 'landingzone=networking_hub' and 'environment=%s' tags, found %d", expected, test.Environment, actual))
 }
+
+func TestVirtualNetworksAreInDifferentRegions(t *testing.T) {
+	t.Parallel()
+
+	test := prepareTestTable()
+
+	vnet1, _ := azure.GetVirtualNetworkE(fmt.Sprintf("%s-vnet-hub-re1", test.Prefix), fmt.Sprintf("%s-rg-vnet-hub-re1", test.Prefix), test.SubscriptionID)
+
+	vnet2, _ := azure.GetVirtualNetworkE(fmt.Sprintf("%s-vnet-hub-re2", test.Prefix), fmt.Sprintf("%s-rg-vnet-hub-re2", test.Prefix), test.SubscriptionID)
+
+	assert.NotEqual(t, *vnet1.Location, *vnet2.Location, "Virtual Networks in the 'landingzone=networking_hub' resource groups should provisioned in different regions")
+}

--- a/tests/level3_test.go
+++ b/tests/level3_test.go
@@ -124,6 +124,26 @@ func TestJumpboxInboundSecurityRules(t *testing.T) {
 		assert.ElementsMatch(t, test.Config.JumpboxInboundRules, actual, fmt.Sprintf("Jumpbox doesn't have expected destination ports: %+q", test.Config.JumpboxInboundRules))
 	}
 }
+
+func TestJumpboxOutboundSecurityRules(t *testing.T) {
+	t.Parallel()
+
+	test := prepareTestTable()
+
+	for iLoop := 1; iLoop <= 2; iLoop++ {
+		rules := azure.GetAllNSGRules(t, fmt.Sprintf("%s-rg-vnet-hub-re%d", test.Prefix, iLoop), fmt.Sprintf("%s-nsg-jumpbox", test.Prefix), test.SubscriptionID)
+		actual := make([]string, 0)
+
+		for _, rule := range rules.SummarizedRules {
+			if rule.Direction == "Outbound" {
+				actual = append(actual, rule.DestinationPortRange)
+			}
+		}
+
+		assert.ElementsMatch(t, test.Config.JumpboxOutboundRules, actual, fmt.Sprintf("Jumpbox doesn't have expected destination ports: %+q", test.Config.JumpboxOutboundRules))
+	}
+}
+
 func TestPrivateEndpointsSecurityRulesCount(t *testing.T) {
 	t.Parallel()
 

--- a/tests/level3_test.go
+++ b/tests/level3_test.go
@@ -74,6 +74,26 @@ func TestBastionSubNetInboundSecurityRules(t *testing.T) {
 		assert.ElementsMatch(t, test.Config.BastionInboundRules, actual, fmt.Sprintf("Bastion Subnet doesn't have expected destination ports: %+q", test.Config.BastionInboundRules))
 	}
 }
+
+func TestBastionSubNetOutboundSecurityRules(t *testing.T) {
+	t.Parallel()
+
+	test := prepareTestTable()
+
+	for iLoop := 1; iLoop <= 2; iLoop++ {
+		rules := azure.GetAllNSGRules(t, fmt.Sprintf("%s-rg-vnet-hub-re%d", test.Prefix, iLoop), fmt.Sprintf("%s-nsg-AzureBastionSubnet", test.Prefix), test.SubscriptionID)
+		actual := make([]string, 0)
+
+		for _, rule := range rules.SummarizedRules {
+			if rule.Direction == "Outbound" {
+				actual = append(actual, rule.DestinationPortRange)
+			}
+		}
+
+		assert.ElementsMatch(t, test.Config.BastionOutboundRules, actual, fmt.Sprintf("Bastion Subnet doesn't have expected destination ports: %+q", test.Config.BastionOutboundRules))
+	}
+}
+
 func TestJumpboxSecurityRulesCount(t *testing.T) {
 	t.Parallel()
 

--- a/tests/level3_test.go
+++ b/tests/level3_test.go
@@ -43,3 +43,15 @@ func TestVirtualNetworksAreInDifferentRegions(t *testing.T) {
 
 	assert.NotEqual(t, *vnet1.Location, *vnet2.Location, "Virtual Networks in the 'landingzone=networking_hub' resource groups should provisioned in different regions")
 }
+
+func TestBastionSubNetSecurityRulesCount(t *testing.T) {
+	t.Parallel()
+
+	test := prepareTestTable()
+
+	for iLoop := 1; iLoop <= 2; iLoop++ {
+		rules := azure.GetAllNSGRules(t, fmt.Sprintf("%s-rg-vnet-hub-re%d", test.Prefix, iLoop), fmt.Sprintf("%s-nsg-AzureBastionSubnet", test.Prefix), test.SubscriptionID)
+
+		assert.Equal(t, 12, len(rules.SummarizedRules), fmt.Sprintf("Bastion Subnet should have 12 rules, found %d", len(rules.SummarizedRules)))
+	}
+}

--- a/tests/level3_test.go
+++ b/tests/level3_test.go
@@ -1,0 +1,10 @@
+package caf_tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/azure"
+	"github.com/stretchr/testify/assert"
+)

--- a/tests/level3_test.go
+++ b/tests/level3_test.go
@@ -56,6 +56,24 @@ func TestBastionSubNetSecurityRulesCount(t *testing.T) {
 	}
 }
 
+func TestBastionSubNetInboundSecurityRules(t *testing.T) {
+	t.Parallel()
+
+	test := prepareTestTable()
+
+	for iLoop := 1; iLoop <= 2; iLoop++ {
+		rules := azure.GetAllNSGRules(t, fmt.Sprintf("%s-rg-vnet-hub-re%d", test.Prefix, iLoop), fmt.Sprintf("%s-nsg-AzureBastionSubnet", test.Prefix), test.SubscriptionID)
+		actual := make([]string, 0)
+
+		for _, rule := range rules.SummarizedRules {
+			if rule.Direction == "Inbound" {
+				actual = append(actual, rule.DestinationPortRange)
+			}
+		}
+
+		assert.ElementsMatch(t, test.Config.BastionInboundRules, actual, fmt.Sprintf("Bastion Subnet doesn't have expected destination ports: %+q", test.Config.BastionInboundRules))
+	}
+}
 func TestJumpboxSecurityRulesCount(t *testing.T) {
 	t.Parallel()
 

--- a/tests/level3_test.go
+++ b/tests/level3_test.go
@@ -174,3 +174,22 @@ func TestPrivateEndpointsInboundSecurityRules(t *testing.T) {
 		assert.ElementsMatch(t, test.Config.PrivateEndpointsInboundRules, actual, fmt.Sprintf("PrivateEndpoints doesn't have expected destination ports: %+q", test.Config.PrivateEndpointsInboundRules))
 	}
 }
+
+func TestPrivateEndpointsOutboundSecurityRules(t *testing.T) {
+	t.Parallel()
+
+	test := prepareTestTable()
+
+	for iLoop := 1; iLoop <= 2; iLoop++ {
+		rules := azure.GetAllNSGRules(t, fmt.Sprintf("%s-rg-vnet-hub-re%d", test.Prefix, iLoop), fmt.Sprintf("%s-nsg-private_endpoints", test.Prefix), test.SubscriptionID)
+		actual := make([]string, 0)
+
+		for _, rule := range rules.SummarizedRules {
+			if rule.Direction == "Outbound" {
+				actual = append(actual, rule.DestinationPortRange)
+			}
+		}
+
+		assert.ElementsMatch(t, test.Config.PrivateEndpointsOutboundRules, actual, fmt.Sprintf("PrivateEndpoints doesn't have expected destination ports: %+q", test.Config.PrivateEndpointsOutboundRules))
+	}
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -39,7 +39,6 @@ main() {
   find_and_export_prefix
 
   export ENVIRONMENT=${ENVIRONMENT}
-  export LOCATION=$(cat config.json | jq -r ".location")
 
   go test -v ./...
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1,7 +1,9 @@
 package caf_tests
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 )
 
@@ -42,6 +44,16 @@ func prepareTestTable() TestStructure {
 		Environment:    os.Getenv("ENVIRONMENT"),
 		LandingZones:   make([]LandingZone, 0),
 	}
+
+	jsonFile, err := os.Open("config.json")
+	if err != nil {
+		fmt.Println(err)
+	}
+	defer jsonFile.Close()
+
+	byteValue, _ := ioutil.ReadAll(jsonFile)
+
+	json.Unmarshal(byteValue, &test.Config)
 
 	for iLoop := 0; iLoop < 4; iLoop++ {
 		test.LandingZones = append(test.LandingZones, LandingZone{

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -29,7 +29,6 @@ func prepareTestTable() TestStructure {
 		Prefix:         prefix,
 		SubscriptionID: os.Getenv("ARM_SUBSCRIPTION_ID"),
 		Environment:    os.Getenv("ENVIRONMENT"),
-		Location:       os.Getenv("LOCATION"),
 		LandingZones:   make([]LandingZone, 0),
 	}
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -20,6 +20,16 @@ type TestStructure struct {
 	LandingZones   []LandingZone
 }
 
+type Config struct {
+	Location                      string   `json:"location"`
+	BastionInboundRules           []string `json:"bastionInboundRules"`
+	BastionOutboundRules          []string `json:"bastionOutboundRules"`
+	JumpboxInboundRules           []string `json:"jumpboxInboundRules"`
+	JumpboxOutboundRules          []string `json:"jumpboxOutboundRules"`
+	PrivateEndpointsInboundRules  []string `json:"privateEndpointsInboundRules"`
+	PrivateEndpointsOutboundRules []string `json:"privateEndpointsOutboundRules"`
+}
+
 // Data-Driven Testing approach implemented
 // https://en.wikipedia.org/wiki/Data-driven_testing
 func prepareTestTable() TestStructure {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -18,6 +18,7 @@ type TestStructure struct {
 	SubscriptionID string
 	Location       string
 	LandingZones   []LandingZone
+	Config         Config
 }
 
 type Config struct {


### PR DESCRIPTION
initial tests for the networking level (Level 3)

the following tests are implemented;

- TestThereAreTwoResourceGroupsForNetworkingHub
- TestVirtualNetworksAreInDifferentRegions
- TestBastionSubNetSecurityRulesCount
- TestBastionSubNetInboundSecurityRules
- TestBastionSubNetOutboundSecurityRules
- TestJumpboxSecurityRulesCount
- TestJumpboxInboundSecurityRules
- TestJumpboxOutboundSecurityRules
- TestPrivateEndpointsSecurityRulesCount
- TestPrivateEndpointsInboundSecurityRules
- TestPrivateEndpointsOutboundSecurityRules

To run the tests, there is a helper bash script `run_tests.sh`

Arguments of the helper is the following;

- "LANDING_ZONES_FOLDER" -z --zones
- "CONFIG_FOLDER" -c --config
- "ENVIRONMENT" -e --environment
- "CREATE_ENV" -ce --create-env
- "DEBUG_FLAG" -d --debug

If you want to both _deploy the infrastructure_ AND _run the tests_, execute the following command;

```bash
./run_tests.sh -z ~/caf/caf-terraform-landingzones -c ~/caf/caf-terraform-landingzones-starter/configuration -e demo -ce -d
```

If you just want to run the tests against an existing infrastructure, execute the following command;

```bash
./run_tests.sh -e demo -d
```
