### PR TITLE
Level 2 Shared Services Test Refactor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "go.testTags":  "level0,level1,level2,level3,level4",
+  "go.testTags": "level0,level1,level2,networking,sharedsvc,level3,level4",
+  "go.testEnvFile": "${workspaceFolder}/tests/.env",
 }

--- a/tests/level0_test.go
+++ b/tests/level0_test.go
@@ -8,22 +8,11 @@ import (
 	"strings"
 
 	"github.com/gruntwork-io/terratest/modules/azure"
-	"github.com/joho/godotenv"
 
-	"log"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-func TestMain(m *testing.M) {
-	err := godotenv.Load()
-	if err != nil {
-		log.Println("No .env file found")
-	}
-	os.Exit(m.Run())
-}
 
 func TestLaunchpadLandingZoneKey(t *testing.T) {
 	//arrange
@@ -107,15 +96,14 @@ func TestLaunchpadResourceGroupHasKeyVault(t *testing.T) {
 	}
 }
 
-
 func TestLaunchpadKeyVaultHasTags(t *testing.T) {
 	t.Parallel()
-  tfState := NewTerraformState(t, "launchpad")
+	tfState := NewTerraformState(t, "launchpad")
 	resourceGroups := tfState.GetResourceGroups()
 
 	for _, resourceGroup := range resourceGroups {
 		rgName := resourceGroup.GetName()
-    level := resourceGroup.GetLevel()
+		level := resourceGroup.GetLevel()
 
 		if !strings.Contains(rgName, "security") {
 			keyVault, err := tfState.GetKeyVaultByResourceGroup(rgName)
@@ -130,20 +118,20 @@ func TestLaunchpadKeyVaultHasTags(t *testing.T) {
 
 			//assert
 			assert.NotNil(t, kv, fmt.Sprintf("KeyVault (%s) does not exists", keyVaultName))
-      assert.Equal(t, tfState.Environment, *kv.Tags["environment"], "Environment Tag is not correct")
-		  assert.Equal(t, tfState.Key, *kv.Tags["landingzone"], "LandingZone Tag is not correct")
-		  assert.Equal(t, level, *kv.Tags["level"], "Level Tag is not correct")
-		  assert.Equal(t, level, *kv.Tags["tfstate"], "TF State Tag is not correct")
+			assert.Equal(t, tfState.Environment, *kv.Tags["environment"], "Environment Tag is not correct")
+			assert.Equal(t, tfState.Key, *kv.Tags["landingzone"], "LandingZone Tag is not correct")
+			assert.Equal(t, level, *kv.Tags["level"], "Level Tag is not correct")
+			assert.Equal(t, level, *kv.Tags["tfstate"], "TF State Tag is not correct")
 		}
 	}
 }
 
 func TestLaunchpadResourceGroupHasStorageAccount(t *testing.T) {
 	t.Parallel()
-  tfState := NewTerraformState(t, "launchpad")
+	tfState := NewTerraformState(t, "launchpad")
 	resourceGroups := tfState.GetResourceGroups()
 
-  for _, resourceGroup := range resourceGroups {
+	for _, resourceGroup := range resourceGroups {
 		rgName := resourceGroup.GetName()
 		if !strings.Contains(rgName, "security") {
 			storageAccount, err := tfState.GetStorageAccountByResourceGroup(rgName)
@@ -154,10 +142,10 @@ func TestLaunchpadResourceGroupHasStorageAccount(t *testing.T) {
 			storageAccountName := storageAccount.GetName()
 
 			//act
-      storageAccountExists := azure.StorageAccountExists(t, storageAccountName, rgName, tfState.SubscriptionID)
+			storageAccountExists := azure.StorageAccountExists(t, storageAccountName, rgName, tfState.SubscriptionID)
 
-      //assert
-      assert.True(t, storageAccountExists, "storage account does not exist")
+			//assert
+			assert.True(t, storageAccountExists, "storage account does not exist")
 
 		}
 	}
@@ -165,13 +153,12 @@ func TestLaunchpadResourceGroupHasStorageAccount(t *testing.T) {
 
 func TestLaunchpadStorageAccountHasTags(t *testing.T) {
 	t.Parallel()
-  tfState := NewTerraformState(t, "launchpad")
+	tfState := NewTerraformState(t, "launchpad")
 	resourceGroups := tfState.GetResourceGroups()
 
-
-  for _, resourceGroup := range resourceGroups {
+	for _, resourceGroup := range resourceGroups {
 		rgName := resourceGroup.GetName()
-    level := resourceGroup.GetLevel()
+		level := resourceGroup.GetLevel()
 
 		if !strings.Contains(rgName, "security") {
 			storageAccount, err := tfState.GetStorageAccountByResourceGroup(rgName)
@@ -181,16 +168,15 @@ func TestLaunchpadStorageAccountHasTags(t *testing.T) {
 
 			storageAccountName := storageAccount.GetName()
 
-
 			//act
-      localStorage, err := azure.GetStorageAccountE(storageAccountName, rgName, tfState.SubscriptionID)
+			localStorage, err := azure.GetStorageAccountE(storageAccountName, rgName, tfState.SubscriptionID)
 
-      //assert
-      assert.NotNil(t, localStorage, fmt.Sprintf("Storage Account (%s) does not exists", storageAccountName))
-      assert.NoError(t, err, "Storage Account couldn't read")
-      assert.Equal(t, tfState.Environment, *localStorage.Tags["environment"], "Environment Tag is not correct")
-		  assert.Equal(t, tfState.Key, *localStorage.Tags["landingzone"], "LandingZone Tag is not correct")
-      assert.Equal(t, level, *localStorage.Tags["level"], "Level Tag is not correct")
+			//assert
+			assert.NotNil(t, localStorage, fmt.Sprintf("Storage Account (%s) does not exists", storageAccountName))
+			assert.NoError(t, err, "Storage Account couldn't read")
+			assert.Equal(t, tfState.Environment, *localStorage.Tags["environment"], "Environment Tag is not correct")
+			assert.Equal(t, tfState.Key, *localStorage.Tags["landingzone"], "LandingZone Tag is not correct")
+			assert.Equal(t, level, *localStorage.Tags["level"], "Level Tag is not correct")
 
 		}
 	}
@@ -198,10 +184,10 @@ func TestLaunchpadStorageAccountHasTags(t *testing.T) {
 
 func TestLaunchpadStorageAccountHasTFStateContainer(t *testing.T) {
 	t.Parallel()
-  tfState := NewTerraformState(t, "launchpad")
+	tfState := NewTerraformState(t, "launchpad")
 	resourceGroups := tfState.GetResourceGroups()
 
-  for _, resourceGroup := range resourceGroups {
+	for _, resourceGroup := range resourceGroups {
 		rgName := resourceGroup.GetName()
 		if !strings.Contains(rgName, "security") {
 			storageAccount, err := tfState.GetStorageAccountByResourceGroup(rgName)
@@ -210,13 +196,13 @@ func TestLaunchpadStorageAccountHasTFStateContainer(t *testing.T) {
 			}
 
 			storageAccountName := storageAccount.GetName()
-      containerName := "tfstate"
+			containerName := "tfstate"
 
 			//act
-      exists := azure.StorageBlobContainerExists(t, containerName, storageAccountName, rgName, tfState.SubscriptionID)
+			exists := azure.StorageBlobContainerExists(t, containerName, storageAccountName, rgName, tfState.SubscriptionID)
 
-      //assert
-		  assert.True(t, exists, "TF State Container does not exist")
+			//assert
+			assert.True(t, exists, "TF State Container does not exist")
 
 		}
 	}

--- a/tests/level2_networking_test.go
+++ b/tests/level2_networking_test.go
@@ -1,3 +1,5 @@
+// +build level2,networking
+
 package caf_tests
 
 import (

--- a/tests/level3_test.go
+++ b/tests/level3_test.go
@@ -1,3 +1,5 @@
+// +build level3
+
 package caf_tests
 
 import (

--- a/tests/level4_test.go
+++ b/tests/level4_test.go
@@ -1,3 +1,5 @@
+// +build level4
+
 package caf_tests
 
 import (

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -1,0 +1,19 @@
+// +build level0 level1 level2 networking sharedsvc level3 level4
+
+package caf_tests
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/joho/godotenv"
+)
+
+func TestMain(m *testing.M) {
+	err := godotenv.Load()
+	if err != nil {
+		log.Println("No .env file found")
+	}
+	os.Exit(m.Run())
+}

--- a/tests/tfstate.go
+++ b/tests/tfstate.go
@@ -19,6 +19,8 @@ type AzureResource struct {
 type ResourceGroups = map[string](AzureResource)
 type KeyVaults = map[string](AzureResource)
 type StorageAccounts = map[string](AzureResource)
+type RecoveryVaults = map[string](AzureResource)
+
 type TerraFormState struct {
 	Objects        Resource
 	SubscriptionID string
@@ -30,7 +32,7 @@ var TfState TerraFormState
 
 func NewTerraformState(t *testing.T, key string) *TerraFormState {
 	tfState := new(TerraFormState)
-  os.Unsetenv("TF_DATA_DIR")
+	os.Unsetenv("TF_DATA_DIR")
 	options := &terraform.Options{
 		TerraformDir: os.Getenv("STATE_FILE_PATH"),
 	}
@@ -68,8 +70,8 @@ func (tfState TerraFormState) GetResourceGroups() ResourceGroups {
 	resourceList := tfState.Objects[tfState.Key].(Resource)
 	resourceGroups := resourceList["resource_groups"].(Resource)
 	var m ResourceGroups = make(ResourceGroups)
-	for key, resourceGroup := range resourceGroups {
-		rg := resourceGroup.(Resource)
+	for key, item := range resourceGroups {
+		rg := item.(Resource)
 		m[key] = *NewAzureResource(rg)
 	}
 	return m
@@ -81,9 +83,22 @@ func (tfState TerraFormState) GetKeyVaults() KeyVaults {
 
 	var m KeyVaults
 	m = make(KeyVaults)
-	for key, resourceGroup := range keyVaults {
-		kv := resourceGroup.(Resource)
+	for key, item := range keyVaults {
+		kv := item.(Resource)
 		m[key] = *NewAzureResource(kv)
+	}
+	return m
+}
+
+func (tfState TerraFormState) GetRecoveryVaults() RecoveryVaults {
+	resourceList := tfState.Objects[tfState.Key].(Resource)
+	recoveryVaults := resourceList["recovery_vaults"].(Resource)
+
+	var m RecoveryVaults
+	m = make(RecoveryVaults)
+	for key, item := range recoveryVaults {
+		rv := item.(Resource)
+		m[key] = *NewAzureResource(rv)
 	}
 	return m
 }


### PR DESCRIPTION
This PR includes the following updates:

* Modify level 2 shared services tests to use state file.
* Add helper methods for Recovery Vaults in tfstate.go
* Introduce setup.go for running go tests directly in cli.
* Add testEnvFile setting for debugging.
* Add build tags to all level tests.

